### PR TITLE
fix `defp` and `defprotocol` snippet conflict

### DIFF
--- a/snippets/language-elixir.cson
+++ b/snippets/language-elixir.cson
@@ -30,7 +30,7 @@
     'prefix': 'mdoc'
     'body': '@moduledoc """\n$0\n"""'
   'defprotocol':
-    'prefix': 'defp'
+    'prefix': 'defpro'
     'body': 'defprotocol $1 do\n\t$0\nend'
   'defimpl':
     'prefix': 'defi'


### PR DESCRIPTION
`defp` and `defprotocol` are both using the same trigger: `defp`. This means that the `defp` snippet is inaccessible. Since the trigger `defp` makes most sense in the context of the `defp` snippet, this pull request proposes that the `defprotocol` snippet trigger be changed to `defpro`.

![screen shot 2015-05-19 at 11 38 59 am](https://cloud.githubusercontent.com/assets/73101/7709878/38c93256-fe1d-11e4-9c3e-9beb9fbc6905.png)
