### PR TITLE
Add `do` snippet

### DIFF
--- a/snippets/language-elixir.cson
+++ b/snippets/language-elixir.cson
@@ -20,6 +20,9 @@
   'defp':
     'prefix': 'defp'
     'body': 'defp $1 do\n\t$0\nend'
+  'do':
+    'prefix': 'do'
+    'body': 'do\n\t$0\nend'
   'doc':
     'prefix': 'doc'
     'body': '@doc """\n$0\n"""'


### PR DESCRIPTION
Always when I write a ``do`` manually and press enter I get a ``@doc``

![Screen](http://i.imgur.com/cUkreQW.gif)

---

I added a ``do`` snippet to avoid that.

![Screen](http://i.imgur.com/2naxpf9.gif)