### PR TITLE
added the grammar and snippet for defoverridable

### DIFF
--- a/grammars/elixir.cson
+++ b/grammars/elixir.cson
@@ -57,7 +57,7 @@
     ]
   }
   {
-    'match': '(?<!\\.)\\b(do|end|case|bc|lc|for|if|cond|unless|try|receive|fn|defmodule|defp?|defprotocol|defimpl|defrecord|defstruct|defmacrop?|defdelegate|defcallback|defexception|exit|after|rescue|catch|else|raise|throw|import|require|alias|use|quote|unquote|super|when)\\b(?![?!])'
+    'match': '(?<!\\.)\\b(do|end|case|bc|lc|for|if|cond|unless|try|receive|fn|defmodule|defp?|defprotocol|defimpl|defrecord|defstruct|defmacrop?|defdelegate|defcallback|defexception|defoverridable|exit|after|rescue|catch|else|raise|throw|import|require|alias|use|quote|unquote|super|when)\\b(?![?!])'
     'name': 'keyword.control.elixir'
   }
   {

--- a/snippets/language-elixir.cson
+++ b/snippets/language-elixir.cson
@@ -38,6 +38,9 @@
   'defimpl':
     'prefix': 'defi'
     'body': 'defimpl ${1:protocol}, for: ${2:type} do\n\t$0\nend'
+  'defoverridable':
+    'prefix': 'defover'
+    'body': 'defoverridable [${1:function_name}: ${2:arity}]'
   'IO.inspect':
     'prefix': 'ii'
     'body': 'IO.inspect($0)'


### PR DESCRIPTION
I found that defoverridable do not gets highlighted like other keywords. I'm totally new to atom plugins, so please be patient.
I'm not sure about the snippet part....could someone please have a look?