### PR TITLE
Index the `fn` pattern

### DIFF
--- a/settings/language-elixir.cson
+++ b/settings/language-elixir.cson
@@ -1,5 +1,5 @@
 '.source.elixir':
   'editor':
     'commentStart': '# '
-    'increaseIndentPattern': '(after|else|catch|rescue|^.*(do|<\\-|\\->|\\{|\\[))\\s*$'
+    'increaseIndentPattern': '(after|else|catch|rescue|fn|^.*(do|<\\-|\\->|\\{|\\[))\\s*$'
     'decreaseIndentPattern': '^\\s*((\\}|\\])\\s*$|(after|else|catch|rescue|end)\\b)'


### PR DESCRIPTION
If someone wants to create an anonymous function that has multiple clauses then we should indent the next line for them so that everything looks correct.

Fixes #18 